### PR TITLE
Depend on MapboxCommon over HTTPS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         )
     ],
     dependencies: [
-        .package(url: "git@github.com:mapbox/mapbox-common-ios.git", from: mapboxCommonVersion),
+        .package(url: "https://github.com/mapbox/mapbox-common-ios.git", from: mapboxCommonVersion),
     ],
     targets: [
         registry.mapboxNavigationNativeTarget(version: version, checksum: checksum),


### PR DESCRIPTION
The mapbox/mapbox-common-ios repository is public. The MapboxNavigationNative package should depend on it over HTTPS instead of SSH, so that downstream packages can build on CI without requiring [arcane workarounds](https://stackoverflow.com/a/58186048/4585461).

/cc @SiarheiFedartsou