### PR TITLE
Fix checksum

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 let registry = SDKRegistry()
 let version = "45.0.1"
 let mapboxCommonVersion = Version("10.0.0-beta.12") 
-let checksum = "8fd54eee4277f1327015cc0bcaed8a878bf44d1804364cd5d93dfab9e2d1a5af"
+let checksum = "feefa910c95e1dead8668a7d8a871b243a3fa688fed85b66c1483d0c33254bb1"
 
 let package = Package(
     name: "MapboxNavigationNative",


### PR DESCRIPTION
Corrected the checksum for v45.0.1. After merging, this commit would need to be tagged as `45.0.1.2` to avoid conflicting with a future v45.0.2. We’ll also have to figure out why the release bot was calculating the wrong checksums in the first place.

Fixes part of #3 temporarily.