### PR TITLE
Add an explicit "activesupport" version for CocoaPods to avoid a bug in 7.1.0 version

### DIFF
--- a/Tests/CocoaPods/Gemfile
+++ b/Tests/CocoaPods/Gemfile
@@ -1,2 +1,3 @@
 source 'https://rubygems.org'
+gem 'activesupport', '~> 7.0', '<= 7.0.8'
 gem 'cocoapods'


### PR DESCRIPTION
CocoaPods doesn't specify the version of `activesupport` gem and it looks like the most recent one (7.1.0) has a bug in it that causes https://github.com/mapbox/mapbox-navigation-native-ios/blob/main/Tests/test_cocoapods.sh to fail.

This pull request explicitly install `activesupport` version  '~> 7.0', '<= 7.0.8'.