### PR TITLE
Remove Common as an explicit dependency and pin NN

### DIFF
--- a/Tests/SPM/project.yml
+++ b/Tests/SPM/project.yml
@@ -2,11 +2,8 @@ name: SPMTest
 options:
   bundleIdPrefix: com.mapbox.navigationnative.SPM
 packages:
-  MapboxCommon:
-    from: 24.3.0
-    url: https://github.com/mapbox/mapbox-common-ios.git
   MapboxNavigationNative:
-    from: 305.0.0-SNAPSHOT.0415T1011Z.20ef9c7
+    version: 305.0.0-SNAPSHOT.0415T1011Z.20ef9c7
     url: https://github.com/mapbox/mapbox-navigation-native-ios.git
 
 targets:

--- a/scripts/change_version.py
+++ b/scripts/change_version.py
@@ -81,12 +81,8 @@ def change_test_spm_project(version, common_version):
     with open(TEST_SPM_PROJECT, 'r') as f:
         spm_project = f.read()
         spm_project = re.sub(
-            r'MapboxNavigationNative:\n.+from: .+', 
-            f'MapboxNavigationNative:\n    from: {version}', 
-            spm_project)
-        spm_project = re.sub(
-            r'MapboxCommon:\n.+from: .+', 
-            f'MapboxCommon:\n    from: {common_version}', 
+            r'MapboxNavigationNative:\n.+version: .+', 
+            f'MapboxNavigationNative:\n    version: {version}', 
             spm_project)
 
     with open(TEST_SPM_PROJECT, 'w') as f:


### PR DESCRIPTION
Turns out that `from: 305.0.0-SNAPSHOT.0411T2348Z.fb6a533` in SPM will be resolved to `305.0.0` even if a valid tag for the snapshot exists.
Because of this integration tests in this repo were testing the latest stable build instead of the released snapshot.

Also removing a direct dependency on CommonSDK in the test app, it should be resolved from NN Package.swift.