### PR TITLE
Remove empty `MapboxNavigationNativeTests` target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,10 +28,6 @@ let package = Package(
             name: "MapboxNavigationNative",
             url: "https://api.mapbox.com/downloads/v2/mobile-navigation-native/releases/ios/packages/\(version)/MapboxNavigationNative.xcframework.zip",
             checksum: checksum
-        ),
-        .testTarget(
-            name: "MapboxNavigationNativeTests",
-            dependencies: ["MapboxNavigationNative"]
         )
     ],
     cxxLanguageStandard: .cxx14


### PR DESCRIPTION
Fix issues shown when running:

```
$ swift package describe
error: Source files for target MapboxNavigationNativeTests should be located under 'Tests/MapboxNavigationNativeTests', or a custom sources path can be set with the 'path' property in Package.swift
```