### PR TITLE
Explicitly specify macOS min version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,8 @@ let checksum = "e9dfbb670e6c635496c45eb5bc62ad0bfbbffccd87b14d8d070f275d853307a2
 
 let package = Package(
     name: "MapboxNavigationNative",
-    platforms: [.iOS(.v12)],
+    // The NavNative SDK doesn't support macOS but declares the minimum macOS requirement with downstream dependencies to enable `swift run` CLI tools
+    platforms: [.iOS(.v12), .macOS(.v10_15)],
     products: [
         .library(
             name: "MapboxNavigationNative",


### PR DESCRIPTION
https://mapbox.atlassian.net/browse/NAVIOS-1813

In order to be able to build a Nav iOS CLI tool, we need to be able to run `swift build` in the Nav repo. With the current `Package.swift` in the NN repo, this command returns an error:
> error: the library 'MapboxNavigationNativeWrapper' requires macos 10.13, but depends on the product 'MapboxCommon' which requires macos 10.15; consider changing the library 'MapboxNavigationNativeWrapper' to require macos 10.15 or later, or the product 'MapboxCommon' to require macos 10.13 or earlier.

Package.swift should explicitly specify the minimum supported version. If the version for mac OS  is not explicitly specified, the minimum version is `macOS 10.13`

> By default, the Swift Package Manager assigns a predefined minimum deployment version for each supported platforms unless you configure supported platforms using the platforms API. This predefined deployment version is the oldest deployment target version that the installed SDK supports for a given platform. One exception to this rule is macOS, for which the minimum deployment target version starts from 10.10.

[The docs](https://github.com/swiftlang/swift-package-manager/blob/main/Documentation/PackageDescription.md#supportedplatform)

[The Maps SDK](https://github.com/mapbox/mapbox-maps-ios/blob/86476e9828bb3a61527a00f767d45a19f93219f5/Package.swift#L16) and [the Common SDK](https://github.com/mapbox/mapbox-common-ios/blob/f70d6553ff21b0a3caf6e473f382d8a5db135d2e/Package.swift#L12) specify the min mac OS version as `10.5`. So the NN, Nav iOS sdk can specify mac OS version as `10.5`